### PR TITLE
Python - Highlight logical operators with Dark Goldenrod 3

### DIFF
--- a/themes/Handmade Dark-color-theme.json
+++ b/themes/Handmade Dark-color-theme.json
@@ -15,18 +15,18 @@
 		"sideBar.dropBackground": "#161616",
 
 		"statusBar.background": "#161616",
-		
+
 		"titleBar.activeBackground": "#161616",
 		"sideBarTitle.foreground": "#bbbbbb",
-		
+
 		"menu.background": "#161616",
-		
+
 		"panel.background": "#161616",
-		
+
 		"dropdown.background": "#161616",
-		
+
 		"terminal.background": "#161616",
-		
+
 		"activityBar.background": "#161616",
 		"activityBarBadge.background": "#161616"
 	},
@@ -76,7 +76,7 @@
 				"meta.use.php",
 				"markup.underline",
 				"markup.raw.block.fenced.markdown",
-				"markup.table",	
+				"markup.table",
 				"support.function",
 				"support.type",
 				"support.class",
@@ -114,6 +114,7 @@
 				"keyword.control",
 				"keyword.other.unit",
 				"keyword.other",
+                "keyword.operator.logical.python",
 				"storage.type",
 				"storage.modifier",
 				"entity.name.type",
@@ -134,7 +135,7 @@
 				"entity.name.function.decorator.python",
 				"punctuation.definition.decorator.python",
 				"support.type"
-				
+
 			],
 			"settings": {
 				"foreground": "#cd950c",

--- a/themes/Handmade Dark-color-theme.json
+++ b/themes/Handmade Dark-color-theme.json
@@ -114,7 +114,7 @@
 				"keyword.control",
 				"keyword.other.unit",
 				"keyword.other",
-                "keyword.operator.logical.python",
+				"keyword.operator.logical.python",
 				"storage.type",
 				"storage.modifier",
 				"entity.name.type",


### PR DESCRIPTION
Adds `keyword.operator.logical.python` scope to the `Foreground - Dark Goldenrod 3` highlighting rule.

I think highlighting logical operators in Python makes it easier to read:

#### With highlighting:
![Screenshot 2024-09-10 at 3 05 25 PM](https://github.com/user-attachments/assets/39cd53d5-3b37-4820-8f5f-a563916d4aab)

#### Without highlighting:
![Screenshot 2024-09-10 at 3 05 34 PM](https://github.com/user-attachments/assets/90f0a1dd-28d2-4237-a07c-ef4a303d2ece)
